### PR TITLE
Develop : Changes as per latest PR and Cross Compatability

### DIFF
--- a/include/igraph_paths.h
+++ b/include/igraph_paths.h
@@ -234,7 +234,7 @@ IGRAPH_EXPORT igraph_error_t igraph_spanner(const igraph_t *graph,
 
 IGRAPH_EXPORT igraph_error_t igraph_steiner_dreyfus_wagner(const igraph_t *graph,
                                                            const igraph_vector_int_t *steiner_terminals,
-                                                           igraph_neimode_t mode, const igraph_vector_t *weights,
+                                                           igraph_i_directed_t mode, const igraph_vector_t *weights,
                                                            igraph_integer_t *result);
 
 IGRAPH_EXPORT igraph_error_t igraph_get_widest_paths(const igraph_t *graph,

--- a/src/paths/steiner.cpp
+++ b/src/paths/steiner.cpp
@@ -163,7 +163,7 @@ igraph_i_directed_t mode, const igraph_vector_t *weights,igraph_integer_t *res)
 			indexOfSubsetD = fetchIndexofMapofSets(D);
 			for (igraph_integer_t j = 0; j < igraph_vector_size(&steiner_vertices); j++)
 			{
-				igraph_integer_t u = IGRAPH_INTEGER_MAX;
+				igraph_real_t distance1 = IGRAPH_INFINITY;
 				std::set<igraph_integer_t>::iterator subset_D_iterator;
 
 				for (subset_D_iterator = D.begin(); subset_D_iterator != D.end(); subset_D_iterator++)
@@ -189,20 +189,20 @@ igraph_i_directed_t mode, const igraph_vector_t *weights,igraph_integer_t *res)
 
 					igraph_integer_t indexOfSubsetDMinusE = fetchIndexofMapofSets(DMinusE);
 
-					if (distanceEJ + (MATRIX(dp_cache, indexOfSubsetDMinusE, j)) < u)
+					if (distanceEJ + (MATRIX(dp_cache, indexOfSubsetDMinusE, j)) < distance1)
 					{
-						u = distanceEJ + (MATRIX(dp_cache, indexOfSubsetDMinusE, j));
+						distance1 = distanceEJ + (MATRIX(dp_cache, indexOfSubsetDMinusE, j));
 					}
 				}
 				for (igraph_integer_t k = 0; k < igraph_vector_size(&steiner_vertices); k++)
 				{
-					MATRIX(dp_cache, indexOfSubsetD, k) = std::min(MATRIX(dp_cache, indexOfSubsetD, k), MATRIX(distance, k, j) + u);
+					MATRIX(dp_cache, indexOfSubsetD, k) = std::min(MATRIX(dp_cache, indexOfSubsetD, k), MATRIX(distance, k, j) + distance1);
 				}
 			}
 		}
 	}
-	igraph_integer_t u = IGRAPH_INTEGER_MAX;
-	igraph_integer_t v = IGRAPH_INTEGER_MAX;
+	igraph_real_t distance1 = IGRAPH_INFINITY;
+	igraph_real_t distance2 = IGRAPH_INFINITY;
 
 	for (igraph_integer_t j = 0; j < igraph_vector_size(&steiner_vertices); j++)
 	{
@@ -225,17 +225,17 @@ igraph_i_directed_t mode, const igraph_vector_t *weights,igraph_integer_t *res)
 
 			igraph_integer_t indexOfSubsetCMinusF = fetchIndexofMapofSets(CMinusF);
 
-			if (distanceFJ + (MATRIX(dp_cache, indexOfSubsetCMinusF, j)) < u)
+			if (distanceFJ + (MATRIX(dp_cache, indexOfSubsetCMinusF, j)) < distance1)
 			{
-				u = distanceFJ + (MATRIX(dp_cache, indexOfSubsetCMinusF, j));
+				distance1 = distanceFJ + (MATRIX(dp_cache, indexOfSubsetCMinusF, j));
 			}
 		}
-		if (MATRIX(distance, q, j) + u < v)
+		if (MATRIX(distance, q, j) + distance1 < distance2)
 		{
-			v = MATRIX(distance, q, j) + u;
+			distance2 = MATRIX(distance, q, j) + distance1;
 		}
 	}
-	*res = v;
+	*res = distance2;
 	//std::cout << u << " " << v << std::endl;
 	igraph_vector_destroy(&steiner_vertices);
 	

--- a/src/paths/steiner.cpp
+++ b/src/paths/steiner.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <set>
 #include <iostream>
+#include <algorithm>
 
 std::map<std::set<igraph_integer_t>, igraph_integer_t> subsetMap;
 
@@ -107,7 +108,7 @@ igraph_neimode_t mode, const igraph_vector_t *weights,igraph_integer_t *res)
 	IGRAPH_CHECK(igraph_matrix_init(&distance,no_of_vertices,no_of_vertices));
 	IGRAPH_FINALLY(igraph_matrix_destroy,&distance);
 
-	igraph_shortest_paths_johnson(graph, &distance, igraph_vss_all(), igraph_vss_all(), weights);
+	igraph_distances_johnson(graph, &distance, igraph_vss_all(), igraph_vss_all(), weights);
 	
 	//printf("Johnson Works\n");
 	

--- a/src/paths/steiner.cpp
+++ b/src/paths/steiner.cpp
@@ -87,7 +87,7 @@ igraph_integer_t fetchIndexofMapofSets(std::set<igraph_integer_t> subset)
 }
 
 igraph_error_t igraph_steiner_dreyfus_wagner(const igraph_t *graph,const igraph_vector_int_t* steiner_terminals,
-igraph_neimode_t mode, const igraph_vector_t *weights,igraph_integer_t *res)
+igraph_i_directed_t mode, const igraph_vector_t *weights,igraph_integer_t *res)
 {
 
 	igraph_integer_t no_of_vertices = (igraph_integer_t)igraph_vcount(graph);


### PR DESCRIPTION
- Changed `igraph_neimode_t` to `igraph_i_directed_t` because `IGRAPH_UNDIRECTED` enum is defined in the latter.
- Changed `igraph_integer_t` to `igraph_real_t` for long long int to long double and their respective variable names.
- Need to test the windows version in the PR of the original Igraph